### PR TITLE
study variable references a single study variable group

### DIFF
--- a/schema/mzTab_2_1-M.json
+++ b/schema/mzTab_2_1-M.json
@@ -5500,9 +5500,7 @@
             {
               "items": {
                 "type": "integer"
-              },
-              "type": "array"
-            },
+              }
             {
               "type": "null"
             }
@@ -5515,7 +5513,7 @@
           "non_indexed_list_value": false,
           "object_level_value": false,
           "referenced_field_name": "study_variable_group",
-          "title": "Group Refs",
+          "title": "Group Ref",
           "validation_policy": {
             "enforcement_level": "required",
             "maximum": null,
@@ -5525,7 +5523,7 @@
             "value_constraint": "non-negative-integer"
           },
           "examples": [
-            "MTD\tstudy_variable[1]-group_ref\tstudy_variable_group[1]| study_variable_group[2]"
+            "MTD\tstudy_variable[1]-group_ref\tstudy_variable_group[1]"
           ]
         },
         "assay_refs": {


### PR DESCRIPTION
This PR changes the n:m mapping between study variables to study variable groups to a n:1 mapping, i.e. a study variable can only reference a **single** study variable group.

Why?

Supporting a n:m mapping would make export/import unnecessarily complicated. Also, I don't see a reason/use case for this.

This is related to issue #125